### PR TITLE
Fix OneFrame plugin registration

### DIFF
--- a/Assets/Morpeh.Helpers/OneFrame/OneFramePlugin.cs
+++ b/Assets/Morpeh.Helpers/OneFrame/OneFramePlugin.cs
@@ -4,7 +4,7 @@
 
     [Preserve]
     public sealed class OneFramePlugin : IWorldPlugin {
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         public static void Init() {
             WorldExtensions.AddWorldPlugin(new OneFramePlugin());
         }


### PR DESCRIPTION
Изменил момент регистрации плагина на RuntimeInitializeLoadType.SubsystemRegistration, чтобы плагин регистрировался до авто-инициализации дефолтного мира